### PR TITLE
Make gen_random() random

### DIFF
--- a/core/lib/contikiecc/ecc/ecdsa.c
+++ b/core/lib/contikiecc/ecc/ecdsa.c
@@ -78,7 +78,6 @@ gen_random(NN_DIGIT *a, uint8_t length)
 */	
   int ri;
   for(ri=0; ri<length; ri++) { 
-    random_init(100);
     a[ri] = ((uint32_t)rand() << 16)^((uint32_t)rand());
   }
 


### PR DESCRIPTION
random_init() effectively calls srand() that reset the seed for the pseudo-random sequence. Because it is used within a loop, it will cause all the NN_DIGIT of a to be equal.

Hope it helps.

Regards,
Tony
